### PR TITLE
Feat/move through songs history

### DIFF
--- a/app/_components/SongView/AudioFeatureTabs.jsx
+++ b/app/_components/SongView/AudioFeatureTabs.jsx
@@ -155,21 +155,29 @@ export default function AudioFeatureTabs({ song }) {
                 <span>Year:</span>
                 <span className="text-gray-700">{formatYear(song)}</span>
               </div>
+              <div className="flex gap-2 text-gray-600 text-sm">
+                <span>Randomized On:</span>
+                <span className="text-gray-700">{song.date}</span>
+              </div>
             </div>
           </div>
           {/* Song genres */}
           <div className="flex flex-col gap-2">
             <span className="text-sm font-medium text-gray-700">Genres:</span>
-            <div className="flex flex-wrap gap-2">
-              {song.genres.map((g, i) => (
-                <span
-                  key={i}
-                  className="text-sm text-gray-700 bg-gray-200 px-3 py-1 rounded-sm"
-                >
-                  {g}
-                </span>
-              ))}
-            </div>
+            {song.genres.length > 0 ? (
+              <div className="flex flex-wrap gap-2">
+                {song.genres.map((g, i) => (
+                  <span
+                    key={i}
+                    className="text-sm text-gray-700 bg-gray-200 px-3 py-1 rounded-sm"
+                  >
+                    {g}
+                  </span>
+                ))}
+              </div>
+            ) : (
+              <span className="text-sm text-gray-700">No genres available</span>
+            )}
           </div>
         </div>
       ),

--- a/app/_components/SongView/SongViews/DefaultView.jsx
+++ b/app/_components/SongView/SongViews/DefaultView.jsx
@@ -117,7 +117,7 @@ export default function DefaultView() {
               <div className="w-full lg:w-[48%] md:pt-8 md:pb-6 pt-6">
                 <div className="w-full flex flex-col justify-between gap-4 md:h-full md:border-l md:border-gray-200 lg:pl-5 lg:pr-2">
                   <div>
-                    <div className="pt-2">
+                    <div className="pt-4 md:pt-6">
                       <ScrollingTitle
                         text={song.track_name}
                         className="text-gray-700 font-medium text-heading-5"

--- a/app/_components/SongView/SongViews/HistoryView.jsx
+++ b/app/_components/SongView/SongViews/HistoryView.jsx
@@ -1,8 +1,5 @@
-import { useState } from "react";
 import { createPortal } from "react-dom";
 import { createArtists } from "../../../utils/createArtists.js";
-import { useSongViewContext } from "../../../context/song-view-context.js";
-import { useMusicContext } from "../../../context/music-context.js";
 import { useStyleContext } from "../../../context/style-context.js";
 import { useHistoryContext } from "../../../context/history-context.js";
 import AudioPlayer from "../AudioPlayer/AudioPlayer.jsx";
@@ -10,11 +7,13 @@ import ScrollingTitle from "../../ui/ScrollingTitle.jsx";
 import { ArrowRight, ArrowLeft, X } from "lucide-react";
 import Image from "next/image";
 import AudioFeatureTabs from "../AudioFeatureTabs.jsx";
+import { hsla } from "motion";
 
 export default function HistoryView() {
   const { styleContext } = useStyleContext();
   const { historyContext } = useHistoryContext();
   const song = historyContext.selectedSong.song;
+  const index = historyContext.selectedSong.index;
   const isOpen = historyContext.isDetailsOpen; // true = detailed view, false = not detailed
   const isMobile = styleContext.isMobile;
 
@@ -60,13 +59,13 @@ export default function HistoryView() {
               <div className="flex flex-row justify-between md:justify-end gap-3">
                 <div className="flex flex-row">
                   <button
-                    // onClick={() => musicContext.moveBackward()}
+                    onClick={() => historyContext.moveBackward(index)}
                     className=" text-gray-600 hover:text-gray-700 hover:bg-gray-200 p-2 rounded-sm"
                   >
                     <ArrowLeft size={iconSize} />
                   </button>
                   <button
-                    // onClick={() => musicContext.moveForward()}
+                    onClick={() => historyContext.moveForward(index)}
                     className=" text-gray-600 hover:text-gray-700 hover:bg-gray-200 p-2 rounded-sm"
                   >
                     <ArrowRight size={iconSize} />
@@ -113,7 +112,7 @@ export default function HistoryView() {
               <div className="w-full lg:w-[48%] md:pt-8 md:pb-6 pt-6">
                 <div className="w-full flex flex-col justify-between gap-4 md:h-full md:border-l md:border-gray-200 lg:pl-5 lg:pr-2">
                   <div>
-                    <div className="pt-2">
+                    <div className="pt-4 md:pt-6">
                       <ScrollingTitle
                         text={song.track_name}
                         className="text-gray-700 font-medium text-heading-5"

--- a/app/context/history-context.js
+++ b/app/context/history-context.js
@@ -5,6 +5,7 @@ import {
   getThisMonth,
   getPast6Months,
 } from "../utils/getDates.js";
+import { networkInterfaces } from "os";
 
 const HistoryContext = createContext();
 
@@ -175,6 +176,32 @@ export const HistoryProvider = ({ children }) => {
     return songs.length;
   }
 
+  function moveForward(index) {
+    console.log(
+      "Moving forward",
+      index,
+      songHistory.allSongsChronological[index + 1],
+    );
+    if (index < songHistory.allSongsChronological.length - 1) {
+      let newIndex = index + 1;
+      setSelectedSong({
+        index: newIndex,
+        song: songHistory.allSongsChronological[newIndex],
+      });
+    }
+  }
+
+  function moveBackward(index) {
+    console.log("Moving backward", index);
+    if (index > 0) {
+      let newIndex = index - 1;
+      setSelectedSong({
+        index: newIndex,
+        song: songHistory.allSongsChronological[newIndex],
+      });
+    }
+  }
+
   const historyContext = {
     isLoading,
     // Songs
@@ -201,6 +228,9 @@ export const HistoryProvider = ({ children }) => {
     visibleCount,
     setVisibleCount,
     loadMoreSongs,
+    //portal
+    moveForward,
+    moveBackward,
   };
 
   const context = {


### PR DESCRIPTION
Added:

- moveForward and moveBackward functions in the context (refactor it to not take a index?)
- padding on top of the song title
- a randomized on value in the details tab
- a display text if the genres length is 0